### PR TITLE
Workaround for webkit's E:target ~ E { … } bug.

### DIFF
--- a/styles/projection.css
+++ b/styles/projection.css
@@ -1,6 +1,9 @@
 @import url(reset.css);
 @import url(fonts.css);
 
+/* Fix for +/~ selectors in webkit */
+@-webkit-keyframes bugfix { from { padding:0; } to { padding:0; } }
+
 BODY {
 	overflow:hidden;
 	background:#000;
@@ -337,6 +340,7 @@ A {
 	-webkit-border-radius:0.2em;
 	-moz-border-radius:0.2em;
 	border-radius:0.2em;
+	-webkit-animation:bugfix infinite 1s;
 	}
 	.progress DIV {
 		position:absolute;
@@ -354,5 +358,5 @@ A {
 		transition:width 0.2s linear;
 		}
 .progress-off:target ~ .progress {
-	display:none;
+	visibility:hidden;
 	}


### PR DESCRIPTION
Using visibility:hidden for hiding .progress and bugfix animation on it fixes the problem.
