### PR TITLE
Latest Chrome does not work in full-screen mode

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -64,6 +64,13 @@
 	function updateView() {
 		linkScreen.disabled = fullscreen;
 		linkProjection.disabled = !fullscreen;
+		if (fullscreen) {
+			linkScreen.setAttribute('disabled', 'disabled');
+			linkProjection.removeAttribute('disabled');
+		} else {
+			linkScreen.removeAttribute('disabled');
+			linkProjection.setAttribute('disabled', 'disabled');
+		}
 		if(!hashList[url.hash]) turnSlide(0);
 	}
 	


### PR DESCRIPTION
It seems that in script.js:66 setting the `disabled` attribute to `false` does not really enable the stylesheet. Chrome seems to disable it depending on the _existance_ of the attribute and not the _value_.

The attached patch fixes this.
