### PR TITLE
Fixing webkit shadow hover bug

### DIFF
--- a/themes/ribbon/styles/screen.css
+++ b/themes/ribbon/styles/screen.css
@@ -345,8 +345,11 @@ body {
 		z-index:-1;
 		width:512px;
 		height:320px;
-		box-shadow:0 20px 50px rgba(42, 43, 45, 0.6);
-	    border-radius:2px;
+		/* rgba(0, 0, 0, 0.005) part fixes webkit hover bug */
+		box-shadow:
+			0 0 30px rgba(0, 0, 0, 0.005),
+			0 20px 50px rgba(42, 43, 45, 0.6);
+		border-radius:2px;
 		content:'';
 		-webkit-transform-origin:0 0;
 		-moz-transform-origin:0 0;
@@ -490,7 +493,7 @@ body {
 	.full .progress div {
 		width:0;
 		height:10px;
-	    box-shadow:0 0 0 1px rgba(255, 255, 255, 0.4);
+		box-shadow:0 0 0 1px rgba(255, 255, 255, 0.4);
 		border-radius:5px;
 		background:rgba(177, 177, 177, 0.4);
 		-webkit-transition:width 0.2s linear;


### PR DESCRIPTION
That's somewhat a strange fix, however, it works. Adding extra `0 0 30px rgba(0, 0, 0, 0.005)` shadow fixes the problem.

Also, replaced two 4-spaced indents to tabs for consistency.
