### PR TITLE
Fix issue on presentation load

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -54,6 +54,10 @@
 	}
 
 	function scrollToCurrentSlide() {
+		if (-1 === getCurrentSlideNumber()) {
+			return;
+		}
+
 		var currentSlide = document.getElementById(
 			slideList[getCurrentSlideNumber()].id
 		);


### PR DESCRIPTION
When I load [example presentation](http://pepelsbey.github.com/shower/en.htm) i have error at `script.js:58` in Chrome 18.0.1025.113 beta:

```
Uncaught TypeError: Cannot read property 'id' of undefined
```

This is quick fix of this issue.
