### PR TITLE
Made simple <mark> not to destroy the monospace grid

### DIFF
--- a/themes/ribbon/styles/screen.css
+++ b/themes/ribbon/styles/screen.css
@@ -142,18 +142,21 @@ body {
 			content:counter(code, decimal-leading-zero)'.';
 			}
 	.slide pre mark {
+		margin:0 -8px;
 		padding:3px 8px;
 		border-radius:8px;
-		background:#FAFAA2;
+		background:rgba(236,249,0,.37);
 		color:#000;
 		font-style:normal;
 		}
 	.slide pre .important {
+		margin:0;
 		background:#C00;
 		color:#FFF;
 		font-weight:normal;
 		}
 	.slide pre .comment {
+		margin:0;
 		padding:0;
 		background:none;
 		color:#999;


### PR DESCRIPTION
Added negative margin to the `<mark>` elements inside the `pre` code blocks, so they now won't destroy the monospace grid.

This can be useful in situations like [this one](http://i.kizu.ru/misc/shower-mark.png) (the first is bad, the second is fixed).

I've replaced the background on mark to the rgba one, so when it would mark something with the letters on the sides, it won't hide them. The alternative here is `position:relative;z-index:-1;`, but I think that it's overhead and the `rgba` solution is better.

However, I removed the negative margin from the `important` mark, 'cause it's so bright that it can't be made to be transparent rgba, so when the mark is under the code, the letter next to the mark become unreadable. You could fix that if you want by changing the color to one less saturated, or by adding white text-shadow to the letter in the simple code + the `position` fix above, in that case the letters over the important mark would be readable.
