### PR TITLE
Don’t override body classes

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -39,12 +39,14 @@
 	}
 
 	function enterSlideMode() {
-		body.className = 'full';
+		body.classList.remove('list');
+		body.classList.add('full');
 		applyTransform(getTransform());
 	}
 
 	function enterListMode() {
-		body.className = 'list';
+		body.classList.remove('full');
+		body.classList.add('list');
 		applyTransform('none');
 	}
 


### PR DESCRIPTION
Shower rewrite body classes. It’s very bad for hacking.

I need extra JS to enable/disable 3D transform depend on slide (because it broke text antialiasing, so I enable it only when visible slides contain 3D).
