### PR TITLE
Using showing without automatic triggering

### DIFF
--- a/shower.js
+++ b/shower.js
@@ -51,7 +51,7 @@ window.shower = window.shower || (function(window, document, undefined) {
 				hasTiming: (shower._getData(slides[i], 'timing') && shower._getData(slides[i], 'timing').indexOf(':') !== -1)
 			});
 		}
-
+		return shower;
 	};
 
 


### PR DESCRIPTION
I would like to integrate shower in another library, but to do that I need to trigger it manually for elements. My usage would be something like this:

``` javascript
var slideshows = [];
// Build list of elements and do some DOM transforms
..
// Enable shower on the found slideshows
slideshows.every(shower);
```

Currently this is not possible because automatically runs for everything `.slide` and has no way to disable that or to manually trigger for another element.
