### PR TITLE
Changing the url for submodule to read-only

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "themes/ribbon"]
 	path = themes/ribbon
-	url = git@github.com:shower/ribbon.git
+	url = git://github.com/shower/ribbon.git


### PR DESCRIPTION
Making this change would allow people to use the repo of the shower in gh-pages — they [can serve the submodules](https://help.github.com/articles/using-submodules-with-pages), but only if they're declared in `git://` syntax.
