### PR TITLE
Enable fullscreen in slide mode

### DIFF
--- a/shower.js
+++ b/shower.js
@@ -276,11 +276,19 @@ window.shower = window.shower || (function(window, document, undefined) {
 	* @returns {Boolean}
 	*/
 	shower.enterSlideMode = function(callback) {
-		var currentSlideNumber = shower.getCurrentSlideNumber();
+		var currentSlideNumber = shower.getCurrentSlideNumber(),
+		    docEl = document.documentElement;
 
 		// Anyway: change body class (@TODO: refactoring)
 		body.classList.remove('list');
 		body.classList.add('full');
+
+		if (docEl.requestFullscreen)
+			docEl.requestFullscreen();
+		else if (docEl.mozRequestFullScreen)
+			docEl.mozRequestFullScreen();
+		else if (docEl.webkitRequestFullScreen)
+			docEl.webkitRequestFullScreen();
 
 		// Preparing URL for shower.go()
 		if (shower.isListMode() && isHistoryApiSupported) {
@@ -307,6 +315,12 @@ window.shower = window.shower || (function(window, document, undefined) {
 		body.classList.add('list');
 
 		shower.clearPresenterNotes();
+		if (document.exitFullScreen)
+			document.cancelFullScreen();
+		else if (document.mozCancelFullScreen)
+			document.mozCancelFullScreen();
+		else if (document.webkitExitFullscreen)
+			document.webkitExitFullscreen();
 
 		if (shower.isListMode()) {
 			return false;


### PR DESCRIPTION
We are looking at enabling the browser's fullscreen mode if supported when entering slide mode. The attached changes are a first cut at doing this. This probably warrants more testing and discussion if this should be enabled by default or a configurable option.
