### PR TITLE
Fix the getCurrentSlideNumber to return 0 when it fails to find a slide

### DIFF
--- a/shower.js
+++ b/shower.js
@@ -599,7 +599,7 @@ window.shower = window.shower || (function(window, document, undefined) {
 	/**
 	* Get current slide number. Starts from zero. Warning: when you have
 	* slide number 1 in URL this method will return 0.
-	* If something is wrong return -1.
+	* If something is wrong return 0 to get the first slide.
 	* @returns {Number}
 	*/
 	shower.getCurrentSlideNumber = function() {
@@ -614,7 +614,7 @@ window.shower = window.shower || (function(window, document, undefined) {
 			}
 		}
 
-		return -1;
+		return 0;
 	};
 
 	/**
@@ -632,11 +632,6 @@ window.shower = window.shower || (function(window, document, undefined) {
 
 		if (shower.isSlideMode()) {
 			throw new Error('You can\'t scroll to because you in slide mode. Please, switch to list mode.');
-		}
-
-		// @TODO: WTF?
-		if (-1 === slideNumber) {
-			return ret;
 		}
 
 		if (shower.slideList[slideNumber]) {
@@ -799,7 +794,7 @@ window.shower = window.shower || (function(window, document, undefined) {
 
 	document.addEventListener('keydown', function(e) {
 		var currentSlideNumber = shower.getCurrentSlideNumber(),
-			slide = shower.slideList[ currentSlideNumber !== -1 ? currentSlideNumber : 0 ],
+			slide = shower.slideList[currentSlideNumber],
 			slideNumber;
 
 		switch (e.which) {
@@ -833,7 +828,7 @@ window.shower = window.shower || (function(window, document, undefined) {
 			break;
 
 			case 13: // Enter
-				if (shower.isListMode() && -1 !== currentSlideNumber) {
+				if (shower.isListMode()) {
 					e.preventDefault();
 
 					shower.enterSlideMode();


### PR DESCRIPTION
As described in #152, it's wrong to return `-1` in case we don't find a slide from a url, so it's so much better to return the first slide in such cases, it won't break anything. And if we'd want to make any assumptions on what to do on error, it is better to be done inside the `getCurrentSlideNumber`.

Also, removed all the checks on the wrong `-1` value, 'cause this function would always return something truthy.
