### PR TITLE
Tool for gh-pages deploing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+deploy:
+	./tools/deploy.sh

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+REPO_URL=`git config --get remote.origin.url`
+
+if [ -d _deploy ];
+    then
+        cd _deploy
+        git pull origin gh-pages
+        cd ../
+    else
+        git clone -b gh-pages "$REPO_URL" _deploy
+fi
+
+rm -rf _deploy/*
+rsync -av --recursive --exclude="_deploy" --exclude="tools" --exclude="Makefile" * _deploy/
+cd _deploy
+git add -A
+git commit -m "update"
+git push origin gh-pages


### PR DESCRIPTION
Hello, Vadim
I've created tool for automatical deploing to gh-pages
## Usage

`make deploy`
## How it works
1. Create gh-pages branch for current repository
2. Create `_deploy` folder
3. Copy all files and folders of presentation into `_deploy`
4. Push content of `_deploy` to github.com
## How does it look

Open in browser: `http://yourName.github.io/project/` and enjoy your presentation :)
