### PR TITLE
Add Netlify support and Netlify button

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Follow [@shower_me](https://twitter.com/shower_me) for support and updates, [fil
 1. Download and unzip [template archive](http://shwr.me/shower.zip)
 2. Open `index.html` and start creating your presentation
 
+## Deploy to Netlify
+
+By clicking the button below you can fork this repo and deploy it to Netlify.
+
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/shower/shower)
+
+ By doing this you would get a GitHub repo linked with Netlify in a way any change to the repo would trigger a shower rebuild and deploy to Netlify servers, which allows for a really easy way to create and share Shower presentation without the need to install anything locally.
+
 ## Advanced
 
 1. Clone this repository locally `git clone git@github.com:shower/shower.git`.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[build]
+  publish = "prepared"
+  command = "npm run prepare"
+


### PR DESCRIPTION
Adds the needed metadata for Netlify to understand which command is needed and where the built files are places after it, as well as adds the text about Netlify support to Readme.

If you'd want to test this without merging, you can use this button with my repo's url: [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/kizu/shower)

Otherwise you won't have the metadata needed to deploy from shower/shower (but the button would work after the merge, of course)