### PR TITLE
Parse component timings without space separators

### DIFF
--- a/packages/core/lib/modules/parse-timing.js
+++ b/packages/core/lib/modules/parse-timing.js
@@ -4,7 +4,7 @@ const hasUnits = (timing) => {
 };
 
 const parseUnits = (timing) => {
-	return units.map((unit) => timing.match(`(\\S+)${unit}`)).map((match) => match && match[1]);
+	return units.map((unit) => timing.match(`([\\d.+-]+)${unit}`)).map((match) => match && match[1]);
 };
 
 const parseColons = (timing) => {

--- a/packages/core/tests/parse-timing.spec.js
+++ b/packages/core/tests/parse-timing.spec.js
@@ -76,5 +76,10 @@ test.describe('parse-timing', () => {
 			expect(p('1.2h 2m 3s')).toBe(4443e3);
 			expect(p('-2.m 3s -1h')).toBe(0);
 		});
+
+		test('no space separator', () => {
+			expect(p('2m30s')).toBe(150e3);
+			expect(p('1h15m45s')).toBe(4545e3);
+		});
 	});
 });


### PR DESCRIPTION
Update parseUnits regex to match number components immediately preceding the unit character, allowing strings like '2m30s' or '1h15m45s' to be parsed correctly. Previously, the greedy non-whitespace pattern matched the entire prefix (e.g. '2m30') for the last unit, resulting in a NaN timing.